### PR TITLE
change(docs): use the default Zcash testnet port, fix addresses

### DIFF
--- a/pool_configs/zclassic.json
+++ b/pool_configs/zclassic.json
@@ -3,16 +3,16 @@
     "coin": "testnet/zec.json",
 
     "address": "tmRGc4CD1UyUdbSJmTUzcB6oDqk4qUaHnnh",
-    "_comment_address": "a transparent address to send coinbase rewards to and to transfer to zAddress. generated using zcash-cli -testnet getnewaddress.",
+    "_comment_address": "This address is currently ignored, but it must be a P2PKH address. generated using zcash-cli -testnet getnewaddress. A transparent address to send coinbase rewards to and to transfer to zAddress."
 
     "zAddress": "",
     "_comment_zAddress": "a private address used to send coins to tAddress.",
 
     "tAddress": "",
-    "_comment_tAddress": "transparent address used to send payments, make this a different address, otherwise payments will not send",
+    "_comment_tAddress": "Payments are currently disabled. Transparent address used to send payments, make this a different address, otherwise payments will not send",
 
-    "invalidAddress":"tmRGc4CD1UyUdbSJmTUzcB6oDqk4qUaHnnh",
-    "_comment_invalidAddress": "Invalid addresses will be converted to the above",
+    "invalidAddress": "tmRGc4CD1UyUdbSJmTUzcB6oDqk4qUaHnnh",
+    "_comment_invalidAddress": "This address is currently ignored. Invalid addresses will be converted to the above",
 
     "walletInterval": 100000,
     "_comment_walletInterval": "Used to cache coin stats",
@@ -32,7 +32,7 @@
         "maxBlocksPerPayment": 3,
         "daemon": {
             "host": "127.0.0.1",
-            "port": 38232,
+            "port": 18232,
             "_comment_port": "change this to your Zebra port",
             "user": "rpcuser",
             "password": "rpcpassword"
@@ -60,13 +60,13 @@
         }
     },
 
-    "poolId": "main",
+    "poolId": "test",
     "_comment_poolId": "use it for region identification: eu, us, asia or keep default if you have one stratum instance for one coin",
 
     "daemons": [
         {
             "host": "127.0.0.1",
-            "port": 38232,
+            "port": 18232,
             "_comment_port": "change this to your Zebra port",
             "user": "rpcuser",
             "password": "rpcpassword",

--- a/pool_configs/zclassic.json
+++ b/pool_configs/zclassic.json
@@ -3,7 +3,7 @@
     "coin": "testnet/zec.json",
 
     "address": "tmRGc4CD1UyUdbSJmTUzcB6oDqk4qUaHnnh",
-    "_comment_address": "This address is currently ignored, but it must be a P2PKH address. generated using zcash-cli -testnet getnewaddress. A transparent address to send coinbase rewards to and to transfer to zAddress."
+    "_comment_address": "This address is currently ignored, but it must be a P2PKH address. generated using zcash-cli -testnet getnewaddress. A transparent address to send coinbase rewards to and to transfer to zAddress.",
 
     "zAddress": "",
     "_comment_zAddress": "a private address used to send coins to tAddress.",

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -134,9 +134,7 @@ Install `s-nomp`:
 Run `s-nomp`:
 1. Edit `pool_configs/zclassic.json` so `daemons[0].port` is your Zebra port
     - TODO: change the pool name to `zcash.json`, does this work?
-2. Optional: update the pool config with your testnet transparent P2PKH address
-    - TODO: use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v` by default
-3. Run `s-nomp` using `npm start`
+2. Run `s-nomp` using `npm start`
 
 Note: the website will log an RPC error even when it is disabled in the config. This seems like a `s-nomp` bug.
 
@@ -161,6 +159,7 @@ make -j $(nproc)
 Run miner:
 1. Follow the run instructions at: https://github.com/nicehash/nheqminer#run-instructions
 ```sh
-# or use your testnet address here - this address will not receive any payments unless it is configued on your node
+# or use your testnet address here
+# miner and pool payments are disabled, configure your address on your node to get paid
 ./nheqminer -l 127.0.0.1:1234 -u tmRGc4CD1UyUdbSJmTUzcB6oDqk4qUaHnnh.worker1 -t 1
 ```

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -10,17 +10,16 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 1. [Install Zebra](https://zebra.zfnd.org/user/install.html) - note: Zebra will need to be compiled with the `getblocktemplate-rpcs` feature, e.g.
     ```sh
-    cargo b --release --features "getblocktemplate-rpcs"
+    cargo build --release --features "getblocktemplate-rpcs"
     ```
 2. Configure `zebrad.toml`:
     * change the `network.network` config to `Testnet`
     * add your testnet transparent address in `mining.miner_address`, or you can use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v`
     * ensure that there is an `rpc.listen_addr` in the config to enable the RPC server
     
+    Example config:
     <details> 
     
-    Example config:
-
     ```console
     [consensus]
     checkpoint_sync = true
@@ -45,14 +44,14 @@ These fixes disable mining pool operator payments and miner payments: they just 
         'testnet.seeder.zfnd.org:18233',
         'testnet.is.yolo.money:18233',
     ]
-    listen_addr = '0.0.0.0:8233'
+    listen_addr = '0.0.0.0:18233'
     network = 'Testnet'
     peerset_initial_target_size = 25
 
     [rpc]
     debug_force_finished_sync = false
     parallel_cpu_threads = 1
-    listen_addr = '127.0.0.1:3000'
+    listen_addr = '127.0.0.1:18232'
 
     [state]
     cache_dir = '/home/ar/.cache/zebra'
@@ -79,7 +78,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
 3. [Run Zebra](https://zebra.zfnd.org/user/run.html) with the `getblocktemplate-rpcs` feature, e.g.
 
     ```sh
-    cargo run --release --features "getblocktemplate-rpcs"`)
+    cargo run --release --features "getblocktemplate-rpcs"
     ```
 
 4. Wait a few hours for Zebra to sync to the testnet tip (on mainnet this takes 2-3 days)
@@ -103,7 +102,7 @@ Install dependencies:
     ```
 2. Install and activate [`nodenv`](https://github.com/nodenv/nodenv#installation) or [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating)
 3. Install `boost` and `libsodium` development libraries
-    On Ubuntu:
+   On Ubuntu:
 
     ```sh
     sudo apt install libboost-all-dev


### PR DESCRIPTION
This PR:
- Changes all the different RPC ports to the default Zcash testnet port
- Changes the sub-pool name to "test"
- Removes miner address instructions (we disabled miner payments because it doesn't work with NU5] 
    - Explains why some addresses are different
- Fixes some formatting issues