### PR TITLE
Switch to the ZcashFoundation node-stratum-pool fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1921,8 +1921,8 @@
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         },
         "stratum-pool": {
-            "version": "git+https://github.com/teor2345/node-stratum-pool.git#75f85dc32ba69241ffd532feb6358e2f1281f68c",
-            "from": "git+https://github.com/teor2345/node-stratum-pool.git#zebra-mining",
+            "version": "git+https://github.com/ZcashFoundation/node-stratum-pool.git#75f85dc32ba69241ffd532feb6358e2f1281f68c",
+            "from": "git+https://github.com/ZcashFoundation/node-stratum-pool.git#zebra-mining",
             "requires": {
                 "async": "^2.6.1",
                 "base58-native": "^0.1.4",
@@ -1981,9 +1981,9 @@
             },
             "dependencies": {
                 "minipass": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.1.tgz",
-                    "integrity": "sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA=="
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.3.tgz",
+                    "integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "nonce": "^1.0.4",
         "redis": "^2.8.0",
         "request": "^2.88.2",
-        "stratum-pool": "git+https://github.com/teor2345/node-stratum-pool.git#zebra-mining"
+        "stratum-pool": "git+https://github.com/ZcashFoundation/node-stratum-pool.git#zebra-mining"
     },
     "engines": {
         "node": ">=8.11"


### PR DESCRIPTION
This PR switches the node-stratum-pool dependency from `teor2345` to `ZcashFoundation`.

The code and commit in the dependency are the same.