### PR TITLE
change(doc): Update the mining setup instructions

### DIFF
--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -111,18 +111,18 @@ These fixes disable mining pool operator payments and miner payments: they just 
 1. `git clone https://github.com/ZcashFoundation/s-nomp`
 2. `cd s-nomp`
 3. Use the Zebra fixes: `git checkout zebra-mining`
-4. Use node 8.17.0:
+4. Use node 8.11.0:
 
     ```sh
-    nodenv install 8.17.0
-    nodenv local 8.17.0
+    nodenv install 8.11.0
+    nodenv local 8.11.0
     ```
 
     or
 
     ```sh
-    nvm install 8.17.0
-    nvm use 8.17.0
+    nvm install 8.11.0
+    nvm use 8.11.0
     ```
 
 5. Update dependencies and install:

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -194,12 +194,39 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 
 ## Install a CPU or GPU miner
 
-Install dependencies:
+### Arch-specific instructions
+
+We're going to install `nheqminer`, which supports various CPU and GPU Equihash
+solvers. We're going to focus on a CPU solver called `tromp` because that one is
+the easiest to install.
+
+#### Install dependencies:
+
+```sh
+sudo pacman -S cmake
+```
+
+#### Install `nheqminer`:
+
+1. `git clone https://github.com/ZcashFoundation/nheqminer`
+2. `cd nheqminer`
+3. Use the Zebra fixes: `git checkout zebra-mining`
+
+```sh
+mkdir build && cd build
+# Turn off CUDA and xenoncat, which are enabled by default, and turn on tromp instead.
+cmake -DUSE_CUDA_DJEZO=OFF -DUSE_CPU_XENONCAT=OFF -DUSE_CPU_TROMP=ON ..
+make -j $(nproc)
+```
+
+### General instructions
+
+#### Install dependencies:
 
 1. Install a statically compiled `boost` and `icu`
 2. Optional: install static CUDA GPU mining libraries: https://github.com/nicehash/nheqminer#linux
 
-Install miner:
+#### Install `nheqminer`:
 
 1. `git clone https://github.com/ZcashFoundation/nheqminer`
 2. `cd nheqminer`
@@ -214,7 +241,7 @@ cmake -DUSE_CUDA_DJEZO=OFF ..
 make -j $(nproc)
 ```
 
-Run miner:
+## Run miner:
 
 1. Follow the run instructions at: https://github.com/nicehash/nheqminer#run-instructions
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -191,7 +191,31 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 
 ## Install a CPU or GPU miner
 
-### Arch-specific instructions
+<details><summary>General instructions</summary>
+
+#### Install dependencies:
+
+1. Install a statically compiled `boost` and `icu`
+2. Optional: install static CUDA GPU mining libraries: https://github.com/nicehash/nheqminer#linux
+
+#### Install `nheqminer`:
+
+1. `git clone https://github.com/ZcashFoundation/nheqminer`
+2. `cd nheqminer`
+3. Use the Zebra fixes: `git checkout zebra-mining`
+4. Follow the build instructions: https://github.com/nicehash/nheqminer#general-instructions
+
+```sh
+mkdir build
+cd build
+# if you have CUDA installed, you can leave USE_CUDA_DJEZO on
+cmake -DUSE_CUDA_DJEZO=OFF ..
+make -j $(nproc)
+```
+
+</details>
+
+<details><summary>Arch-specific instructions</summary>
 
 We're going to install `nheqminer`, which supports various CPU and GPU Equihash
 solvers. We're going to focus on a CPU solver called `tromp` because that one is
@@ -216,27 +240,7 @@ cmake -DUSE_CUDA_DJEZO=OFF -DUSE_CPU_XENONCAT=OFF -DUSE_CPU_TROMP=ON ..
 make -j $(nproc)
 ```
 
-### General instructions
-
-#### Install dependencies:
-
-1. Install a statically compiled `boost` and `icu`
-2. Optional: install static CUDA GPU mining libraries: https://github.com/nicehash/nheqminer#linux
-
-#### Install `nheqminer`:
-
-1. `git clone https://github.com/ZcashFoundation/nheqminer`
-2. `cd nheqminer`
-3. Use the Zebra fixes: `git checkout zebra-mining`
-4. Follow the build instructions: https://github.com/nicehash/nheqminer#general-instructions
-
-```sh
-mkdir build
-cd build
-# if you have CUDA installed, you can leave USE_CUDA_DJEZO on
-cmake -DUSE_CUDA_DJEZO=OFF ..
-make -j $(nproc)
-```
+</details>
 
 ## Run miner:
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -193,18 +193,18 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 
 #### Install dependencies
 
+<details><summary>General instructions</summary>
+
+1. Install a statically compiled `boost` and `icu`.
+2. Install `cmake`.
+
+</details>
+
 <details><summary>Arch-specific instructions</summary>
 
 ```sh
 sudo pacman -S cmake
 ```
-
-</details>
-
-<details><summary>General instructions</summary>
-
-1. Install a statically compiled `boost` and `icu`.
-2. Install `cmake`.
 
 </details>
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -83,7 +83,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 <details><summary>General instructions with Debian/Ubuntu examples</summary>
     
-#### Install dependencies:
+#### Install dependencies
 
 1. Install `redis` and run it on the default port: <https://redis.io/docs/getting-started/>
 
@@ -106,7 +106,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     sudo apt install libsodium-dev
     ```
 
-#### Install `s-nomp`:
+#### Install `s-nomp`
 
 1. `git clone https://github.com/ZcashFoundation/s-nomp`
 2. `cd s-nomp`
@@ -137,7 +137,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 <details><summary>Arch-specific instructions</summary>
     
-#### Install dependencies:
+#### Install dependencies
 
 1. Install [`redis`](https://redis.io/docs/getting-started/) and run it on the default port:
 
@@ -160,7 +160,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     sudo pacman -S boost libsodium
     ```
 
-#### Install `s-nomp`:
+#### Install `s-nomp`
 
 1. `git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp`
 
@@ -182,7 +182,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 </details>
 
-## Run `s-nomp`:
+## Run `s-nomp`
 
 1. Edit `pool_configs/zcash.json` so `daemons[0].port` is your Zebra port
 2. Run `s-nomp` using `npm start`
@@ -191,7 +191,7 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 
 ## Install a CPU or GPU miner
 
-#### Install dependencies:
+#### Install dependencies
 
 <details><summary>Arch-specific instructions</summary>
 
@@ -208,7 +208,7 @@ sudo pacman -S cmake
 
 </details>
 
-#### Install `nheqminer`:
+#### Install `nheqminer`
 
 We're going to install `nheqminer`, which supports multiple CPU and GPU Equihash
 solvers. We're using a CPU solver named `tromp` in the following instructions
@@ -228,7 +228,7 @@ cmake -DUSE_CUDA_DJEZO=OFF -DUSE_CPU_XENONCAT=OFF -DUSE_CPU_TROMP=ON ..
 make -j $(nproc)
 ```
 
-## Run miner:
+## Run miner
 
 1. Follow the run instructions at: <https://github.com/nicehash/nheqminer#run-instructions>
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -191,56 +191,42 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 
 ## Install a CPU or GPU miner
 
-<details><summary>General instructions</summary>
-
 #### Install dependencies:
-
-1. Install a statically compiled `boost` and `icu`
-2. Optional: install static CUDA GPU mining libraries: https://github.com/nicehash/nheqminer#linux
-
-#### Install `nheqminer`:
-
-1. `git clone https://github.com/ZcashFoundation/nheqminer`
-2. `cd nheqminer`
-3. Use the Zebra fixes: `git checkout zebra-mining`
-4. Follow the build instructions: https://github.com/nicehash/nheqminer#general-instructions
-
-```sh
-mkdir build
-cd build
-# if you have CUDA installed, you can leave USE_CUDA_DJEZO on
-cmake -DUSE_CUDA_DJEZO=OFF ..
-make -j $(nproc)
-```
-
-</details>
 
 <details><summary>Arch-specific instructions</summary>
-
-We're going to install `nheqminer`, which supports various CPU and GPU Equihash
-solvers. We're going to focus on a CPU solver called `tromp` because that one is
-the easiest to install.
-
-#### Install dependencies:
 
 ```sh
 sudo pacman -S cmake
 ```
 
+</details>
+
+<details><summary>General instructions</summary>
+
+1. Install a statically compiled `boost` and `icu`.
+2. Install `cmake`.
+
+</details>
+
 #### Install `nheqminer`:
+
+We're going to install `nheqminer`, which supports multiple CPU and GPU Equihash
+solvers. We're using a CPU solver named `tromp` in the following instructions
+since that one is the easiest to install.
 
 1. `git clone https://github.com/ZcashFoundation/nheqminer`
 2. `cd nheqminer`
 3. Use the Zebra fixes: `git checkout zebra-mining`
+4. Follow the build instructions at
+   <https://github.com/nicehash/nheqminer#general-instructions>, or run:
 
 ```sh
-mkdir build && cd build
+mkdir build
+cd build
 # Turn off CUDA and xenoncat, which are enabled by default, and turn on tromp instead.
 cmake -DUSE_CUDA_DJEZO=OFF -DUSE_CPU_XENONCAT=OFF -DUSE_CPU_TROMP=ON ..
 make -j $(nproc)
 ```
-
-</details>
 
 ## Run miner:
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -10,9 +10,11 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 1. [Build Zebra](https://github.com/ZcashFoundation/zebra#build-instructions)
    Zebra will need to be compiled with the `getblocktemplate-rpcs` feature:
+
     ```sh
     cargo build --release --features "getblocktemplate-rpcs"
     ```
+
 2. Configure `zebrad.toml`:
 
     - change the `network.network` config to `Testnet`
@@ -79,9 +81,11 @@ These fixes disable mining pool operator payments and miner payments: they just 
     </details>
 
 3. [Run Zebra](https://zebra.zfnd.org/user/run.html) with the `getblocktemplate-rpcs` feature:
+
     ```sh
     cargo run --release --features "getblocktemplate-rpcs"
     ```
+
 4. Wait a few hours for Zebra to sync to the testnet tip (on mainnet this takes 2-3 days)
 
 ## Install `s-nomp`

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -14,13 +14,14 @@ These fixes disable mining pool operator payments and miner payments: they just 
     cargo build --release --features "getblocktemplate-rpcs"
     ```
 2. Configure `zebrad.toml`:
-    * change the `network.network` config to `Testnet`
-    * add your testnet transparent address in `mining.miner_address`, or you can use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v`
-    * ensure that there is an `rpc.listen_addr` in the config to enable the RPC server
-    
+
+    - change the `network.network` config to `Testnet`
+    - add your testnet transparent address in `mining.miner_address`, or you can use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v`
+    - ensure that there is an `rpc.listen_addr` in the config to enable the RPC server
+
     Example config:
-    <details> 
-    
+    <details>
+
     ```console
     [consensus]
     checkpoint_sync = true
@@ -74,7 +75,9 @@ These fixes disable mining pool operator payments and miner payments: they just 
     [mining]
     miner_address = 't27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v'
     ```
+
     </details>
+
 3. [Run Zebra](https://zebra.zfnd.org/user/run.html) with the `getblocktemplate-rpcs` feature:
     ```sh
     cargo run --release --features "getblocktemplate-rpcs"
@@ -84,8 +87,10 @@ These fixes disable mining pool operator payments and miner payments: they just 
 ## Install and run a mining pool
 
 Install dependencies:
+
 1. Install `redis` and run it on the default port: https://redis.io/docs/getting-started/
    On Ubuntu:
+
     ```sh
     sudo apt install lsb-release
     curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
@@ -96,6 +101,7 @@ Install dependencies:
     sudo apt-get install redis
     redis-server
     ```
+
 2. Install and activate a node version manager (e.g. [`nodenv`](https://github.com/nodenv/nodenv#installation) or [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating))
 3. Install `boost` and `libsodium` development libraries
    On Ubuntu:
@@ -105,15 +111,19 @@ Install dependencies:
     ```
 
 Install `s-nomp`:
+
 1. `git clone https://github.com/ZcashFoundation/s-nomp`
 2. `cd s-nomp`
 3. Use the Zebra fixes: `git checkout zebra-mining`
 4. Use node 8.17.0:
+
     ```sh
     nodenv install 8.17.0
     nodenv local 8.17.0
     ```
-    or 
+
+    or
+
     ```sh
     nvm install 8.17.0
     nvm use 8.17.0
@@ -127,6 +137,7 @@ Install `s-nomp`:
     ```
 
 Run `s-nomp`:
+
 1. Edit `pool_configs/zcash.json` so `daemons[0].port` is your Zebra port
 2. Run `s-nomp` using `npm start`
 
@@ -135,24 +146,29 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 ## Install a CPU or GPU miner
 
 Install dependencies:
+
 1. Install a statically compiled `boost` and `icu`
 2. Optional: install static CUDA GPU mining libraries: https://github.com/nicehash/nheqminer#linux
 
 Install miner:
+
 1. `git clone https://github.com/ZcashFoundation/nheqminer`
 2. `cd nheqminer`
 3. Use the Zebra fixes: `git checkout zebra-mining`
 4. Follow the build instructions: https://github.com/nicehash/nheqminer#general-instructions
+
 ```sh
 mkdir build
 cd build
-# if you have CUDA installed, you can leave USE_CUDA_DJEZO on 
+# if you have CUDA installed, you can leave USE_CUDA_DJEZO on
 cmake -DUSE_CUDA_DJEZO=OFF ..
 make -j $(nproc)
 ```
 
 Run miner:
+
 1. Follow the run instructions at: https://github.com/nicehash/nheqminer#run-instructions
+
 ```sh
 # you can use your own testnet address here
 # miner and pool payments are disabled, configure your address on your node to get paid
@@ -160,8 +176,9 @@ Run miner:
 ```
 
 Notes:
-* A typical solution rate is 2-4 Sols/s per core
-* `nheqminer` sometimes ignores Control-C, if that happens, you can quit it using:
-    * `killall nheqminer`, or
-    * Control-Z then `kill %1`
-* Running `nheqminer` with a single thread (`-t 1`) can help avoid this issue
+
+-   A typical solution rate is 2-4 Sols/s per core
+-   `nheqminer` sometimes ignores Control-C, if that happens, you can quit it using:
+    -   `killall nheqminer`, or
+    -   Control-Z then `kill %1`
+-   Running `nheqminer` with a single thread (`-t 1`) can help avoid this issue

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -85,7 +85,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     
 #### Install dependencies:
 
-1. Install `redis` and run it on the default port: https://redis.io/docs/getting-started/
+1. Install `redis` and run it on the default port: <https://redis.io/docs/getting-started/>
 
     ```sh
     sudo apt install lsb-release
@@ -230,7 +230,7 @@ make -j $(nproc)
 
 ## Run miner:
 
-1. Follow the run instructions at: https://github.com/nicehash/nheqminer#run-instructions
+1. Follow the run instructions at: <https://github.com/nicehash/nheqminer#run-instructions>
 
 ```sh
 # you can use your own testnet address here

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -211,8 +211,8 @@ sudo pacman -S cmake
 #### Install `nheqminer`
 
 We're going to install `nheqminer`, which supports multiple CPU and GPU Equihash
-solvers. We're using a CPU solver named `tromp` in the following instructions
-since that one is the easiest to install.
+solvers, namely `djezo`, `xenoncat`, and `tromp`. We're using `tromp` on a CPU
+in the following instructions since it is the easiest to install and use.
 
 1. `git clone https://github.com/ZcashFoundation/nheqminer`
 2. `cd nheqminer`
@@ -223,7 +223,7 @@ since that one is the easiest to install.
 ```sh
 mkdir build
 cd build
-# Turn off CUDA and xenoncat, which are enabled by default, and turn on tromp instead.
+# Turn off `djezo` and `xenoncat`, which are enabled by default, and turn on `tromp` instead.
 cmake -DUSE_CUDA_DJEZO=OFF -DUSE_CPU_XENONCAT=OFF -DUSE_CPU_TROMP=ON ..
 make -j $(nproc)
 ```

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -81,53 +81,8 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 ## Install `s-nomp`
 
-### Arch-specific instructions
-
-#### Install dependencies:
-
-1. Install [`redis`](https://redis.io/docs/getting-started/) and run it on the default port:
-
-    ```sh
-    sudo pacman -S redis
-    sudo systemctl start redis
-    ```
-
-2. Install and activate [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating):
-
-    ```sh
-    sudo pacman -S nvm
-    unset npm_config_prefix
-    source /usr/share/nvm/init-nvm.sh
-    ```
-
-3. Install `boost` and `libsodium` development libraries:
-
-    ```sh
-    sudo pacman -S boost libsodium
-    ```
-
-#### Install `s-nomp`:
-
-1. `git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp`
-
-2. Use the Zebra configs: `git checkout zebra-mining`
-
-3. Use node 8.11.0:
-
-    ```sh
-    nvm install 8.11.0
-    nvm use 8.11.0
-    ```
-
-4. Update dependencies and install:
-
-    ```sh
-    npm update
-    npm install
-    ```
-
-### General instructions with Debian/Ubuntu examples
-
+<details><summary>General instructions with Debian/Ubuntu examples</summary>
+    
 #### Install dependencies:
 
 1. Install `redis` and run it on the default port: https://redis.io/docs/getting-started/
@@ -177,6 +132,55 @@ These fixes disable mining pool operator payments and miner payments: they just 
     npm update
     npm install
     ```
+
+</details>
+
+<details><summary>Arch-specific instructions</summary>
+    
+#### Install dependencies:
+
+1. Install [`redis`](https://redis.io/docs/getting-started/) and run it on the default port:
+
+    ```sh
+    sudo pacman -S redis
+    sudo systemctl start redis
+    ```
+
+2. Install and activate [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating):
+
+    ```sh
+    sudo pacman -S nvm
+    unset npm_config_prefix
+    source /usr/share/nvm/init-nvm.sh
+    ```
+
+3. Install `boost` and `libsodium` development libraries:
+
+    ```sh
+    sudo pacman -S boost libsodium
+    ```
+
+#### Install `s-nomp`:
+
+1. `git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp`
+
+2. Use the Zebra configs: `git checkout zebra-mining`
+
+3. Use node 8.11.0:
+
+    ```sh
+    nvm install 8.11.0
+    nvm use 8.11.0
+    ```
+
+4. Update dependencies and install:
+
+    ```sh
+    npm update
+    npm install
+    ```
+
+</details>
 
 ## Run `s-nomp`:
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -203,7 +203,7 @@ Note: the website will log an RPC error even when it is disabled in the config. 
 <details><summary>Arch-specific instructions</summary>
 
 ```sh
-sudo pacman -S cmake
+sudo pacman -S cmake boost icu
 ```
 
 </details>

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -19,7 +19,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
     - change the `network.network` config to `Testnet`
     - add your testnet transparent address in `mining.miner_address`, or you can use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v`
-    - ensure that there is an `rpc.listen_addr` in the config to enable the RPC server. For example: `rpc.listen_addr = '127.0.0.1:3000'`.
+    - ensure that there is an `rpc.listen_addr` in the config to enable the RPC server. For example: `rpc.listen_addr = '127.0.0.1:18232'`.
 
     Example config:
     <details>
@@ -121,7 +121,6 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 2. Use the Zebra configs: `git checkout zebra-mining`
 
-    - TODO: change the fork in `package.json` to ZcashFoundation
 
 3. Use node 8.11.0:
 
@@ -137,7 +136,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     npm install
     ```
 
-### Ubuntu-specific and general instructions
+### General instructions with Debian/Ubuntu examples
 
 #### Install dependencies:
 

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -84,12 +84,60 @@ These fixes disable mining pool operator payments and miner payments: they just 
     ```
 4. Wait a few hours for Zebra to sync to the testnet tip (on mainnet this takes 2-3 days)
 
-## Install and run a mining pool
+## Install `s-nomp`
 
-Install dependencies:
+### Arch-specific instructions
+
+#### Install dependencies:
+
+1. Install [`redis`](https://redis.io/docs/getting-started/) and run it on the default port:
+
+    ```sh
+    sudo pacman -S redis
+    sudo systemctl start redis
+    ```
+
+2. Install and activate [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating):
+
+    ```sh
+    sudo pacman -S nvm
+    unset npm_config_prefix
+    source /usr/share/nvm/init-nvm.sh
+    ```
+
+3. Install `boost` and `libsodium` development libraries:
+
+    ```sh
+    sudo pacman -S boost libsodium
+    ```
+
+#### Install `s-nomp`:
+
+1. `git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp`
+
+2. Use the Zebra configs: `git checkout zebra-mining`
+
+    - TODO: change the fork in `package.json` to ZcashFoundation
+
+3. Use node 8.11.0:
+
+    ```sh
+    nvm install 8.11.0
+    nvm use 8.11.0
+    ```
+
+4. Update dependencies and install:
+
+    ```sh
+    npm update
+    npm install
+    ```
+
+### Ubuntu-specific and general instructions
+
+#### Install dependencies:
 
 1. Install `redis` and run it on the default port: https://redis.io/docs/getting-started/
-   On Ubuntu:
 
     ```sh
     sudo apt install lsb-release
@@ -104,13 +152,13 @@ Install dependencies:
 
 2. Install and activate a node version manager (e.g. [`nodenv`](https://github.com/nodenv/nodenv#installation) or [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating))
 3. Install `boost` and `libsodium` development libraries
-   On Ubuntu:
+
     ```sh
     sudo apt install libboost-all-dev
     sudo apt install libsodium-dev
     ```
 
-Install `s-nomp`:
+#### Install `s-nomp`:
 
 1. `git clone https://github.com/ZcashFoundation/s-nomp`
 2. `cd s-nomp`
@@ -130,13 +178,14 @@ Install `s-nomp`:
     ```
 
 5. Update dependencies and install:
+
     ```sh
     export CXXFLAGS="-std=gnu++17"
     npm update
     npm install
     ```
 
-Run `s-nomp`:
+## Run `s-nomp`:
 
 1. Edit `pool_configs/zcash.json` so `daemons[0].port` is your Zebra port
 2. Run `s-nomp` using `npm start`

--- a/zebra-instructions.md
+++ b/zebra-instructions.md
@@ -17,7 +17,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
     - change the `network.network` config to `Testnet`
     - add your testnet transparent address in `mining.miner_address`, or you can use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v`
-    - ensure that there is an `rpc.listen_addr` in the config to enable the RPC server
+    - ensure that there is an `rpc.listen_addr` in the config to enable the RPC server. For example: `rpc.listen_addr = '127.0.0.1:3000'`.
 
     Example config:
     <details>


### PR DESCRIPTION
This PR:

- Adds instructions for Arch-based Linux distros with the following two main differences:
  - I couldn't get `s-nomp` to work under node 8.17.0, but 8.11.0 worked.
  - I couldn't get `nheqminer` to work with the `xenoncat` CPU solver, but `tromp` worked.
- Adds an example for a `listen_addr`, including a port number.
- Reformats the `zebra-instructions.md` file to increase readability. I use a local Markdown renderer that couldn't render some parts properly. If this change is too obtrusive, I can omit it.